### PR TITLE
Changing compile time dependency of identity-local-auth-iwa 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <identity.local.auth.iwa.import.version.range>[5.0.0, 6.0.0)</identity.local.auth.iwa.import.version.range>
 
         <identity.carbon.auth.iwa.export.version>${project.version}</identity.carbon.auth.iwa.export.version>
-        <identity.local.auth.iwa.version>5.1.1</identity.local.auth.iwa.version>
+        <identity.local.auth.iwa.version>5.1.0</identity.local.auth.iwa.version>
 
         <!--Carbon Kernel Version-->
         <carbon.kernel.version>4.4.7</carbon.kernel.version>


### PR DESCRIPTION
Changing compile time dependency version : identity.local.auth.iwa.version to 5.1.0
