### PR TITLE
Address changes required for the migration of STS implementation

### DIFF
--- a/components/org.wso2.carbon.identity.authenticator.iwa.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.authenticator.iwa.ui/pom.xml
@@ -64,6 +64,10 @@
             <artifactId>org.wso2.carbon.identity.base</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.sts</groupId>
+            <artifactId>org.wso2.carbon.identity.sts.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.orbit.com.github.dblock.waffle</groupId>
             <artifactId>waffle-jna</artifactId>
         </dependency>
@@ -94,6 +98,7 @@
                             org.wso2.carbon.core.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.ui; version="${carbon.kernel.package.import.version.range}",
 
+                            org.wso2.carbon.identity.sts.mgt.base; version="${inbound.auth.sts.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.import.version.range}",
                             org.wso2.carbon.identity.authenticator.iwa.stub.client;
                             version="${identity.local.auth.iwa.import.version.range}",

--- a/components/org.wso2.carbon.identity.authenticator.iwa.ui/src/main/java/org/wso2/carbon/identity/authenticator/iwa/ui/IWAUIAuthenticator.java
+++ b/components/org.wso2.carbon.identity.authenticator.iwa.ui/src/main/java/org/wso2/carbon/identity/authenticator/iwa/ui/IWAUIAuthenticator.java
@@ -29,8 +29,8 @@ import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.core.common.AuthenticationException;
 import org.wso2.carbon.core.security.AuthenticatorsConfiguration;
 import org.wso2.carbon.identity.authenticator.iwa.stub.client.IWAAuthenticatorStub;
-import org.wso2.carbon.identity.base.IdentityBaseUtil;
 import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.sts.mgt.base.IdentityBaseUtil;
 import org.wso2.carbon.ui.CarbonUIUtil;
 import org.wso2.carbon.ui.DefaultCarbonAuthenticator;
 

--- a/components/org.wso2.carbon.identity.authenticator.iwa/pom.xml
+++ b/components/org.wso2.carbon.identity.authenticator.iwa/pom.xml
@@ -55,6 +55,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.base</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.sts</groupId>
+            <artifactId>org.wso2.carbon.identity.sts.mgt</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -97,6 +101,7 @@
 
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
 
+                            org.wso2.carbon.identity.sts.mgt.base; version="${inbound.auth.sts.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.import.version.range}",
                         </Import-Package>
                     </instructions>

--- a/components/org.wso2.carbon.identity.authenticator.iwa/src/main/java/org/wso2/carbon/identity/authenticator/iwa/util/IWADeploymentInterceptor.java
+++ b/components/org.wso2.carbon.identity.authenticator.iwa/src/main/java/org/wso2/carbon/identity/authenticator/iwa/util/IWADeploymentInterceptor.java
@@ -30,7 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.neethi.Policy;
 import org.wso2.carbon.identity.authenticator.iwa.IWAException;
-import org.wso2.carbon.identity.base.IdentityBaseUtil;
+import org.wso2.carbon.identity.sts.mgt.base.IdentityBaseUtil;
 
 import java.util.ArrayList;
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,13 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
 
+            <!--Inbound Auth STS dependencies-->
+            <dependency>
+                <groupId>org.wso2.carbon.identity.inbound.auth.sts</groupId>
+                <artifactId>org.wso2.carbon.identity.sts.mgt</artifactId>
+                <version>${inbound.auth.sts.version}</version>
+            </dependency>
+
             <!-- Axis2 dependencies -->
             <dependency>
                 <groupId>org.apache.axis2.wso2</groupId>
@@ -307,9 +314,13 @@
         <!--Carbon Identity Framework Version-->
         <carbon.identity.framework.version>5.14.67</carbon.identity.framework.version>
         <carbon.identity.framework.import.version.range>[5.14.67, 6.0.0)</carbon.identity.framework.import.version.range>
-        <identity.local.auth.iwa.import.version.range>[5.3.0, 6.0.0)</identity.local.auth.iwa.import.version.range>
 
+        <identity.local.auth.iwa.import.version.range>[5.3.0, 6.0.0)</identity.local.auth.iwa.import.version.range>
         <identity.carbon.auth.iwa.export.version>${project.version}</identity.carbon.auth.iwa.export.version>
+
+        <!--Inbound Auth STS Version-->
+        <inbound.auth.sts.version>5.5.3-SNAPSHOT</inbound.auth.sts.version>
+        <inbound.auth.sts.version.range>[5.5.0, 6.0.0)</inbound.auth.sts.version.range>
 
         <!--Carbon Kernel Version-->
         <carbon.kernel.version>4.6.0</carbon.kernel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -312,14 +312,14 @@
 
     <properties>
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.17.77-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.0</carbon.identity.framework.version>
         <carbon.identity.framework.import.version.range>[5.14.67, 6.0.0)</carbon.identity.framework.import.version.range>
 
         <identity.local.auth.iwa.import.version.range>[5.3.0, 6.0.0)</identity.local.auth.iwa.import.version.range>
         <identity.carbon.auth.iwa.export.version>${project.version}</identity.carbon.auth.iwa.export.version>
 
         <!--Inbound Auth STS Version-->
-        <inbound.auth.sts.version>5.5.3-SNAPSHOT</inbound.auth.sts.version>
+        <inbound.auth.sts.version>5.6.0</inbound.auth.sts.version>
         <inbound.auth.sts.version.range>[5.5.0, 6.0.0)</inbound.auth.sts.version.range>
 
         <!--Carbon Kernel Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
 
     <properties>
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.14.67</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.17.77-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.import.version.range>[5.14.67, 6.0.0)</carbon.identity.framework.import.version.range>
 
         <identity.local.auth.iwa.import.version.range>[5.3.0, 6.0.0)</identity.local.auth.iwa.import.version.range>


### PR DESCRIPTION
**Description:**

Since STS implementation is moved from carbon-identity-framework to identity-inbound-auth-sts and WS-Trust is provided as a connector. These changes are to address the changes required for the migration of that implementation.

**Depends On:**

- wso2/carbon-identity-framework#2921
- wso2/wso2-wss4j#82
- wso2-extensions/identity-inbound-auth-openid#68
- wso2-extensions/identity-inbound-auth-sts#90

Resolves: https://github.com/wso2/product-is/issues/8350